### PR TITLE
Pass js-beautify to icons.py

### DIFF
--- a/icons.js
+++ b/icons.js
@@ -46,7 +46,7 @@ define(function () {
         elem.style.backgroundImage = "url('" + url + "')";
     }
 
-    icons.colorize = function(elem, colors) {
+    icons.colorize = function (elem, colors) {
         var iconInfo = {
             "uri": getBackgroundURL(elem),
             "strokeColor": colors[0],


### PR DESCRIPTION
From Crockford style guide, "If a function literal is anonymous, there
should be one space between the word function and the left
parenthesis"
