### PR TITLE
CSS: Add subcell-size variable and use it to define toolbar height

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -20,8 +20,8 @@ body {
 .toolbar {
   color: white;
   background-color: #282828;
-  padding: 0 56px;
-  height: 54px;
+  padding: 0 57px;
+  height: 55px;
   -moz-user-select: none;
   -webkit-user-select: none;
 }
@@ -36,8 +36,8 @@ body {
   border: 0;
   border-radius: 5px;
   margin: 4px 2px;
-  width: 46px;
-  height: 46px;
+  width: 47px;
+  height: 47px;
 }
 .toolbar .toolbutton:hover {
   background-color: black;
@@ -82,7 +82,7 @@ button:focus {
   border-color: white;
 }
 .toolbar button {
-  margin-top: 13px;
+  margin-top: 13.5px;
 }
 /* Button with icon */
 button.icon {
@@ -133,7 +133,7 @@ input[type='text']:disabled {
   background-color: #808080;
 }
 .toolbar input[type='text'] {
-  margin-top: 11px;
+  margin-top: 11.5px;
 }
 /* One line text input with buttons inside */
 .icon-input {
@@ -169,7 +169,7 @@ input[type='text']:disabled {
   background-color: transparent;
 }
 .toolbar .icon-input button {
-  top: 11px;
+  top: 11.5px;
 }
 button.cancel {
   background-image: url(../icons/actions/entry-cancel.svg);
@@ -202,7 +202,7 @@ input[type='range']::-webkit-slider-thumb:hover {
   border-color: #a2a2a2;
 }
 .toolbar input[type='range'] {
-  margin-top: 22px;
+  margin-top: 22.5px;
 }
 /* Label */
 label {

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -4,7 +4,8 @@
 @text-field-grey: #E5E5E5;
 
 @line-width: 2px;
-@toolbar-height: 54px;
+@subcell-size: 11px;
+@toolbar-height: 5 * @subcell-size;
 @icon-small-size: 20px;
 
 @toolbutton-size: @toolbar-height - (4 * @line-width);


### PR DESCRIPTION
According to the HIG [1], the value is 15 pixels for the original XO,
and according to sugar-artwork code, the value for 96 DPI is 11 pixels
(72%).  And the latter is the current CSS being developed.  But we are
ready to start supporting other pixel densities, outputting different
CSS files and using CSS3 media queries [2] to select the correct one
for the user display.

[1] http://wiki.sugarlabs.org/go/Human_Interface_Guidelines/The_Sugar_Interface/Layout_Guidelines
[2] http://www.w3.org/TR/css3-mediaqueries/
