### PR TITLE
Fix activity/activity callbacks, and adapt icon.colorize function

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -22,9 +22,16 @@ define(function (require) {
     activity.getXOColor = function (callback) {
         function onResponseReceived(error, result) {
             if (error === null) {
-                callback(null, ["#00A0FF", "#8BFF7A"]);
-            } else {
-                callback(null, result[0]);
+                callback(null, {
+                    stroke: result[0][0],
+                    fill: result[0][1]
+                });
+            }
+            else {
+                callback(null, {
+                    stroke: "#00A0FF",
+                    fill: "#8BFF7A"
+                });
             }
         }
 
@@ -34,10 +41,11 @@ define(function (require) {
     activity.close = function (callback) {
         function onResponseReceived(error, result) {
             if (error === null) {
+                callback(null);
+            }
+            else {
                 console.log("activity.close called");
             }
-
-            callback(null);
         }
 
         bus.sendMessage("activity.close", [], onResponseReceived);

--- a/graphics/icon.js
+++ b/graphics/icon.js
@@ -48,8 +48,8 @@ define(function () {
     icon.colorize = function (elem, colors) {
         var iconInfo = {
             "uri": getBackgroundURL(elem),
-            "strokeColor": colors[0],
-            "fillColor": colors[1]
+            "strokeColor": colors.stroke,
+            "fillColor": colors.fill
         };
 
         icon.load(iconInfo, function (url) {


### PR DESCRIPTION
Invert the if/else clauses.  If the error === null then there was no
error.

Change the output of activity.getXOColor to be an object with stroke
and fill members instead of an array.  Adape icon.colorize function to
this change.
