### PR TITLE
Tweaks to the low level datastore API

### DIFF
--- a/bus.js
+++ b/bus.js
@@ -88,7 +88,7 @@ define(function (require) {
     };
 
     InputStream.prototype.gotData = function (buffer) {
-        this._readCallback(buffer);
+        this._readCallback(null, buffer);
         this._readCallback = null;
     };
 


### PR DESCRIPTION
loadAata is renamed load and also passes metadata
create does not send the data
update is renamed to save

The main goal is to allow creating objects with no data.
