### PR TITLE
Pass the dependencies to define

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -1,9 +1,9 @@
-define(function (require) {
-    var l10n = require("webL10n");
-    var shortcut = require("sugar-web/activity/shortcut");
-    var bus = require("sugar-web/bus");
-    var env = require("sugar-web/env");
-    var datastore = require("sugar-web/datastore");
+define(["webL10N",
+        "sugar-web/activity/shortcut",
+        "sugar-web/bus",
+        "sugar-web/env",
+        "sugar-web/datastore"], function (
+    l10n, shortcut, bus, env, datastore) {
 
     var datastoreObject = null;
 
@@ -20,9 +20,9 @@ define(function (require) {
 
         env.getEnvironment(function (error, environment) {
             datastoreObject.setMetadata({
-                "activity": environment.bundleId,
-                "activity_id": environment.activityId
-            });
+                    "activity": environment.bundleId,
+                    "activity_id": environment.activityId
+                });
             datastoreObject.save(function () {});
         });
     };
@@ -35,14 +35,14 @@ define(function (require) {
         function onResponseReceived(error, result) {
             if (error === null) {
                 callback(null, {
-                    stroke: result[0][0],
-                    fill: result[0][1]
-                });
+                        stroke: result[0][0],
+                        fill: result[0][1]
+                    });
             } else {
                 callback(null, {
-                    stroke: "#00A0FF",
-                    fill: "#8BFF7A"
-                });
+                        stroke: "#00A0FF",
+                        fill: "#8BFF7A"
+                    });
             }
         }
 

--- a/activity/shortcut.js
+++ b/activity/shortcut.js
@@ -1,4 +1,4 @@
-define(function (require) {
+define(function () {
     var shortcut = {};
 
     shortcut._allShortcuts = [];

--- a/bus.js
+++ b/bus.js
@@ -1,6 +1,4 @@
-define(function (require) {
-    var env = require("sugar-web/env");
-
+define(["sugar-web/env"], function (env) {
     var lastId = 0;
     var callbacks = {};
     var client = null;

--- a/datastore.js
+++ b/datastore.js
@@ -1,7 +1,4 @@
-define(function (require) {
-    var bus = require("sugar-web/bus");
-    var env = require("sugar-web/env");
-
+define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
     var datastore = {};
 
     function DatastoreObject(objectId) {

--- a/env.js
+++ b/env.js
@@ -1,4 +1,4 @@
-define(function (require) {
+define(function () {
 
     var env = {};
 

--- a/graphics/radiobuttonsgroup.js
+++ b/graphics/radiobuttonsgroup.js
@@ -1,6 +1,4 @@
-define(function () {
-    var util = require("sugar-web/graphics/util");
-
+define(["sugar-web/graphics/util"], function (util) {
     var radioButtonsGroup = {};
 
     // ## RadioButtonsGroup

--- a/graphics/xocolor.js
+++ b/graphics/xocolor.js
@@ -1,4 +1,4 @@
-define(function (require) {
+define(function () {
 
     var xocolor = {};
 

--- a/test/busSpec.js
+++ b/test/busSpec.js
@@ -1,6 +1,4 @@
-define(function (require) {
-
-    var bus = require("sugar-web/bus");
+define(["sugar-web/bus"], function (bus) {
 
     describe("datastore", function () {
         var client;

--- a/test/datastoreSpec.js
+++ b/test/datastoreSpec.js
@@ -1,7 +1,4 @@
-define(function (require) {
-
-    var bus = require("sugar-web/bus");
-    var datastore = require("sugar-web/datastore");
+define(["sugar-web/bus", "sugar-web/datastore"], function (bus, datastore) {
 
     describe("datastore object", function () {
 

--- a/test/graphics/paletteSpec.js
+++ b/test/graphics/paletteSpec.js
@@ -1,6 +1,4 @@
-define(function (require) {
-    var palette = require("sugar-web/graphics/palette");
-
+define(["sugar-web/graphics/palette"], function (palette) {
     describe("palette", function () {
         it("should start down", function () {
             var myPalette = new palette.Palette('false invoker');

--- a/test/graphics/radiobuttonsgroupSpec.js
+++ b/test/graphics/radiobuttonsgroupSpec.js
@@ -1,6 +1,6 @@
-define(function (require) {
-    var util = require("sugar-web/graphics/util");
-    var radioButtonsGroup = require("sugar-web/graphics/radiobuttonsgroup");
+define(["sugar-web/graphics/util",
+        "sugar-web/graphics/radiobuttonsgroup"], function (
+    util, radioButtonsGroup) {
 
     beforeEach(function () {
         elem1 = document.createElement('button');

--- a/test/graphics/utilSpec.js
+++ b/test/graphics/utilSpec.js
@@ -1,5 +1,4 @@
-define(function (require) {
-    var util = require("sugar-web/graphics/util");
+define(["sugar-web/graphics/util"], function (util) {
 
     beforeEach(function () {
         elem = document.createElement('div');


### PR DESCRIPTION
Rather than manually requiring. This is necessary for test/ as
explained in the documentation. It's probably not required for
the rest of the code but it feels nicer so I did it everywhere.
