### PR TITLE
CSS: set font family and font size

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -9,6 +9,8 @@ body {
   height: 100%;
   background-color: #c0c0c0;
   position: relative;
+  font-family: sans-serif;
+  font-size: 10pt;
 }
 .unselectable {
   -moz-user-select: none;

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -6,6 +6,7 @@
 @line-width: 2px;
 @subcell-size: 11px;
 @cell-size: 5 * @subcell-size;
+@font-size: 10pt;
 
 @toolbar-height: @cell-size;
 @icon-small-size: 2 * @subcell-size;
@@ -36,6 +37,8 @@ body {
   height: 100%;
   background-color: @panel-grey;
   position: relative;
+  font-family: sans-serif;
+  font-size: @font-size;
 }
 
 .unselectable {


### PR DESCRIPTION
Sugar GTK reads GConf keys '/desktop/sugar/font/default_face' and
'/desktop/sugar/font/default_size'.  Their respective values are Sans
Serif 10.0 for sugar-72 theme and Sans Serif 7.0 for sugar-100 theme.
