### PR TITLE
More on palettes

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -229,9 +229,37 @@ label {
 /* Palettes */
 .palette {
   color: white;
+  background-color: transparent;
+  position: absolute;
+  pointer-events: none;
+}
+.palette-invoker {
+  width: 51px;
+  height: 53px;
+  background-color: black;
+  border: 2px solid #808080;
+  border-bottom: 0;
+  background-position: 2px 2px;
+  background-size: 47px;
+  background-repeat: no-repeat;
+}
+.palette-container {
+  width: 51px;
+  height: 51px;
+  background-color: black;
+  border: 2px solid #808080;
+  min-width: 165px;
+  pointer-events: auto;
+}
+.palette-invoker:before {
+  content: "";
   background-color: black;
   position: absolute;
-  border: 2px solid #808080;
+  display: block;
+  top: 55px;
+  width: 51px;
+  left: 2px;
+  height: 2px;
 }
 /* Scrollbar */
 ::-webkit-scrollbar {

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -309,9 +309,40 @@ label {
 
 .palette {
   color: white;
+  background-color: transparent;
+  position: absolute;
+  pointer-events: none;
+}
+
+.palette-invoker {
+  width: @cell-size - 2 * @line-width;
+  height: @cell-size - @line-width;
+  background-color: black;
+  border: @line-width solid @button-grey;
+  border-bottom: 0;
+  background-position: @line-width @line-width;
+  background-size: @toolbutton-size;
+  background-repeat: no-repeat;
+}
+
+.palette-container {
+  width: @cell-size - 2 * @line-width;
+  height: @cell-size - 2 * @line-width;
+  background-color: black;
+  border: @line-width solid @button-grey;
+  min-width: 3 * @cell-size;
+  pointer-events: auto;
+}
+
+.palette-invoker:before {
+  content: "";
   background-color: black;
   position: absolute;
-  border: @line-width solid @button-grey;
+  display: block;
+  top: @cell-size;
+  width: @cell-size - 2 * @line-width;
+  left: @line-width;
+  height: @line-width;
 }
 
 /* Scrollbar */

--- a/graphics/palette.js
+++ b/graphics/palette.js
@@ -1,13 +1,19 @@
 define(function () {
+    var palettesGroup = [];
 
     function getOffset(elem) {
-        var x = 0;
-        var y = 0;
+        // To consider the margin, this ugly thing needs to be done.
+        // We need to consider the horizontal margin twice to get the
+        // palette border outside the button.
+        var style = elem.currentStyle || window.getComputedStyle(elem, '');
+        // Remove 'px' from the strings.
+        var x = -2 * style.marginLeft.slice(0, -2);
+        var y = -1 * style.marginTop.slice(0, -2);
         var width = elem.offsetWidth;
         var height = elem.offsetHeight;
         while (elem) {
-            x += elem.offsetLeft - elem.scrollLeft;
-            y += elem.offsetTop - elem.scrollTop;
+            x += elem.offsetLeft - elem.scrollLeft + elem.clientLeft;
+            y += elem.offsetTop - elem.scrollTop + elem.clientTop;
             elem = elem.offsetParent;
         }
         return {
@@ -22,50 +28,101 @@ define(function () {
 
     palette.Palette = function (invoker) {
         this.invoker = invoker;
-        var container;
+        var paletteElem;
+        var containerElem;
         var that = this;
+        palettesGroup.push(this);
 
-        function updatePosition() {
-            var invokerOffset = getOffset(that.invoker);
-            container.style.top = invokerOffset.top +
-                invokerOffset.height + "px";
-            container.style.left = invokerOffset.left + "px";
+        invoker.addEventListener('click', function (event) {
+            if (!that.invoker.classList.contains("toolbutton")) {
+                updatePosition(event.x, event.y);
+            }
+            that.toggle();
+        });
+
+        function updatePosition(clickX, clickY) {
+            var paletteX;
+            var paletteY;
+            if (typeof (clickX) !== 'undefined' &&
+                typeof (clickY) !== 'undefined') {
+                paletteX = clickX;
+                paletteY = clickY;
+            } else {
+                var invokerOffset = getOffset(that.invoker);
+                paletteX = invokerOffset.left;
+                paletteY = invokerOffset.top;
+            }
+            paletteElem.style.left = paletteX + "px";
+            paletteElem.style.top = paletteY + "px";
         }
 
-        // create a new container for the content of the palette, removing
-        // the previous content if it had any
+        // create a new palette element with a container, removing the
+        // previous content if it had any
 
-        function createContainer() {
-            if (container !== undefined) {
-                document.body.removeChild(container);
+        function createPalette() {
+            if (paletteElem !== undefined) {
+                return;
             }
-            container = document.createElement('div');
-            container.className = "palette";
-            container.style.visibility = "hidden";
-            document.body.appendChild(container);
+            paletteElem = document.createElement('div');
+            paletteElem.className = "palette";
+            paletteElem.style.visibility = "hidden";
+            document.body.appendChild(paletteElem);
+
+            if (that.invoker.classList.contains("toolbutton")) {
+                invokerElem = document.createElement('div');
+                invokerElem.className = "palette-invoker";
+                var style = that.invoker.currentStyle ||
+                    window.getComputedStyle(that.invoker, '');
+                invokerElem.style.backgroundImage = style.backgroundImage;
+
+                invokerElem.addEventListener('click', function (e) {
+                    that.toggle();
+                });
+
+                paletteElem.appendChild(invokerElem);
+
+            }
+
+            containerElem = document.createElement('div');
+            containerElem.className = "palette-container";
+            paletteElem.appendChild(containerElem);
+
             updatePosition();
         }
 
-        this.getContainer = function () {
-            if (container === undefined) {
-                createContainer();
+        this.getPalette = function () {
+            if (paletteElem === undefined) {
+                createPalette();
             }
-            return container;
+            return paletteElem;
+        };
+
+        this.getContainer = function () {
+            if (paletteElem === undefined) {
+                createPalette();
+            }
+            return containerElem;
         };
 
         this.isDown = function () {
-            return container === undefined ||
-                container.style.visibility == "hidden";
+            return paletteElem === undefined ||
+                paletteElem.style.visibility == "hidden";
         };
 
     };
 
     palette.Palette.prototype.popUp = function () {
-        this.getContainer().style.visibility = "visible";
+        for (var i = 0; i < palettesGroup.length; i++) {
+            otherPalette = palettesGroup[i];
+            if (otherPalette != this) {
+                otherPalette.popDown();
+            }
+        }
+        this.getPalette().style.visibility = "visible";
     };
 
     palette.Palette.prototype.popDown = function () {
-        this.getContainer().style.visibility = "hidden";
+        this.getPalette().style.visibility = "hidden";
     };
 
     palette.Palette.prototype.toggle = function () {

--- a/test/graphics/paletteSpec.js
+++ b/test/graphics/paletteSpec.js
@@ -1,16 +1,31 @@
 define(["sugar-web/graphics/palette"], function (palette) {
     describe("palette", function () {
         it("should start down", function () {
-            var myPalette = new palette.Palette('false invoker');
+            var invoker = document.createElement('button');
+            var myPalette = new palette.Palette(invoker);
             expect(myPalette.isDown()).toBe(true);
         });
 
         it("should toggle", function () {
-            var myPalette = new palette.Palette('false invoker');
+            var invoker = document.createElement('button');
+            var myPalette = new palette.Palette(invoker);
             myPalette.toggle();
             expect(myPalette.isDown()).toBe(false);
             myPalette.toggle();
             expect(myPalette.isDown()).toBe(true);
+        });
+
+        it("if one palette in a group popups, the others popdown", function () {
+            var invokerA = document.createElement('button');
+            var invokerB = document.createElement('button');
+            var myPaletteA = new palette.Palette(invokerA);
+            var myPaletteB = new palette.Palette(invokerB);
+            myPaletteA.toggle();
+            expect(myPaletteA.isDown()).toBe(false);
+            expect(myPaletteB.isDown()).toBe(true);
+            myPaletteB.toggle();
+            expect(myPaletteA.isDown()).toBe(true);
+            expect(myPaletteB.isDown()).toBe(false);
         });
 
     });


### PR DESCRIPTION
Only one palette visible per activity.  A palette popup provokes the
popdown of the current visible one, if any.

If the invoker is a toolbar button, add a background box on top of the
palette, over the button.

If the invoker is not a toolbar button, the palette will popup in the
clicked position.
