### PR TITLE
CSS: resize and center checkboxes and radio buttons

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -320,3 +320,11 @@ input[type='radio']:checked:active {
 input[type='radio']:checked {
   background-image: url(../icons/actions/radio-active.svg);
 }
+/* Textarea */
+textarea {
+  border: 2px solid #808080;
+  margin: 2px;
+}
+textarea.expand {
+  width: calc(100% - 12px);
+}

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -217,7 +217,7 @@ input[type='text'].expand {
 }
 
 .icon-input.expand {
- width: 100%;
+  width: 100%;
 }
 
 .icon-input.expand  input[type='text'] {
@@ -422,4 +422,15 @@ input[type='radio']:checked:active {
 
 input[type='radio']:checked {
   background-image: url(../icons/actions/radio-active.svg);
+}
+
+/* Textarea */
+
+textarea {
+  border: @line-width solid @button-grey;
+  margin: @line-width;
+}
+
+textarea.expand {
+  width: calc(~"100%" - (6 * (@line-width)));
 }


### PR DESCRIPTION
- make them icon-size (two subcells width and height)
- vertically align them in the text
- center them vertically in toolbars
- unify the CSS rules shared by checkboxes and radios
