### PR TITLE
Palette: add header

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -237,7 +237,7 @@ label {
   -moz-user-select: none;
   -webkit-user-select: none;
 }
-/* Palettes */
+/* Palette */
 .palette {
   color: white;
   background-color: transparent;
@@ -254,14 +254,6 @@ label {
   background-size: 47px;
   background-repeat: no-repeat;
 }
-.palette-container {
-  width: 51px;
-  height: 51px;
-  background-color: black;
-  border: 2px solid #808080;
-  min-width: 165px;
-  pointer-events: auto;
-}
 .palette-invoker:before {
   content: "";
   background-color: black;
@@ -271,6 +263,28 @@ label {
   width: 51px;
   left: 2px;
   height: 2px;
+}
+.palette .wrapper {
+  width: 51px;
+  min-height: 51px;
+  background-color: black;
+  border: 2px solid #808080;
+  min-width: 165px;
+  pointer-events: auto;
+}
+.palette .header {
+  height: 51px;
+  line-height: 51px;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  margin: 0 5.5px;
+  font-weight: bold;
+}
+.palette hr {
+  border: 1px solid #808080;
+}
+.palette hr.header-separator {
+  margin-top: 0;
 }
 /* Scrollbar */
 ::-webkit-scrollbar {

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -320,7 +320,7 @@ label {
   .unselectable;
 }
 
-/* Palettes */
+/* Palette */
 
 .palette {
   color: white;
@@ -340,15 +340,6 @@ label {
   background-repeat: no-repeat;
 }
 
-.palette-container {
-  width: @cell-size - 2 * @line-width;
-  height: @cell-size - 2 * @line-width;
-  background-color: black;
-  border: @line-width solid @button-grey;
-  min-width: 3 * @cell-size;
-  pointer-events: auto;
-}
-
 .palette-invoker:before {
   content: "";
   background-color: black;
@@ -358,6 +349,31 @@ label {
   width: @cell-size - 2 * @line-width;
   left: @line-width;
   height: @line-width;
+}
+
+.palette .wrapper {
+  width: @cell-size - 2 * @line-width;
+  min-height: @cell-size - 2 * @line-width;
+  background-color: black;
+  border: @line-width solid @button-grey;
+  min-width: 3 * @cell-size;
+  pointer-events: auto;
+}
+
+.palette .header {
+  height: @cell-size - 2 * @line-width;
+  line-height: @cell-size - 2 * @line-width;
+  .unselectable;
+  margin: 0 (@subcell-size / 2);
+  font-weight: bold;
+}
+
+.palette hr {
+  border: (@line-width / 2) solid @button-grey;
+}
+
+.palette hr.header-separator {
+  margin-top: 0;
 }
 
 /* Scrollbar */


### PR DESCRIPTION
Palette will have a header if the user pass primaryText to the
constructor.  If the user sets content, there will be a separator
between the header and the content.

API change: to set the content, use palette.setContent(content) .
Previously was done using getContainer(), which does not exist
anymore.

Also, improve the offset calculation using
element.getBoundingClientRect
https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
