### PR TITLE
Fix button position when mixing buttons with and without palettes

### DIFF
--- a/graphics/css/sugar.css
+++ b/graphics/css/sugar.css
@@ -65,7 +65,7 @@ a {
   width: 100%;
   height: 100%;
 }
-.toolbar .toolbutton.invoker:before {
+.toolbar .toolbutton:before {
   content: "";
   background-color: transparent;
   position: absolute;
@@ -74,6 +74,8 @@ a {
   height: 11px;
   bottom: -4px;
   right: -4px;
+}
+.toolbar .toolbutton.invoker:before {
   background-image: url('../icons/emblems/arrow-down.svg');
 }
 .toolbar #stop-button {

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -105,7 +105,7 @@ a {
   height: 100%;
 }
 
-.toolbar .toolbutton.invoker:before {
+.toolbar .toolbutton:before {
   content: "";
   background-color: transparent;
   position: absolute;
@@ -114,6 +114,9 @@ a {
   height: @subcell-size;
   bottom: -2 * @line-width;
   right: -2 * @line-width;
+}
+
+.toolbar .toolbutton.invoker:before {
   background-image: url('../icons/emblems/arrow-down.svg');
 }
 


### PR DESCRIPTION
The CSS :before selector is used to add the little arrow in the
button.  This works fine for the current tests, but an important test
was missing: mix buttons with and without palettes.  The mix provoked
a displacement of the buttons with palettes.

This commit fixes that by adding :before to all buttons to make them
have all the same structure in the DOM.  And then adding the arrow
graphic only to the ones with palettes.
