### PR TITLE
Improve metadata handling in activity setup

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -40,10 +40,14 @@ define(["webL10n",
         shortcut.add("Ctrl", "Q", this.close);
 
         env.getEnvironment(function (error, environment) {
-            datastoreObject.setMetadata({
-                "activity": environment.bundleId,
-                "activity_id": environment.activityId
-            });
+            if (!environment.objectId) {
+                datastoreObject.setMetadata({
+                    "title": environment.activityName + " Activity",
+                    "title_set_by_user": "0",
+                    "activity": environment.bundleId,
+                    "activity_id": environment.activityId
+                });
+            };
             datastoreObject.save(function () {
                 datastoreObject.getMetadata(function (error, metadata) {
                     activityPalette.setTitleDescription(metadata);

--- a/graphics/activitypalette.js
+++ b/graphics/activitypalette.js
@@ -1,5 +1,4 @@
-define(["sugar-web/graphics/palette",
-        "sugar-web/env"], function (palette, env) {
+define(["sugar-web/graphics/palette"], function (palette) {
 
     var activitypalette = {};
 
@@ -34,7 +33,8 @@ define(["sugar-web/graphics/palette",
 
         this.titleElem.onblur = function () {
             datastoreObject.setMetadata({
-                "title": this.value
+                "title": this.value,
+                "title_set_by_user": "1"
             });
             datastoreObject.save();
         };
@@ -49,14 +49,7 @@ define(["sugar-web/graphics/palette",
 
     // Fill the text inputs with the received metadata.
     var setTitleDescription = function (metadata) {
-        var that = this;
-        if (metadata.title === undefined) {
-            env.getEnvironment(function (error, environment) {
-                that.titleElem.value = environment.activityName;
-            });
-        } else {
-            this.titleElem.value = metadata.title;
-        }
+        this.titleElem.value = metadata.title;
 
         if (metadata.description !== undefined) {
             this.descriptionElem.value = metadata.description;


### PR DESCRIPTION
- Set metadata only if the activity is not resuming
- Set default title using the activity name
- Add "title_set_by_user" metadata
