### PR TITLE
Ensure object id is set only when needed

### DIFF
--- a/datastore.js
+++ b/datastore.js
@@ -9,7 +9,7 @@ define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
             var that = this;
 
             env.getEnvironment(function (error, environment) {
-                if (environment.objectId !== null) {
+                if (environment.objectId !== null && objectId===undefined) {
                     that.objectId = environment.objectId;
                 }
                 callback();


### PR DESCRIPTION
Set the object id only when object id is not passed as a parameter while creating a Datastore object
