### PR TITLE
Set JS strict mode

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -7,6 +7,8 @@ define(["webL10n",
         "sugar-web/graphics/activitypalette"], function (
     l10n, shortcut, bus, env, datastore, icon, activitypalette) {
 
+    'use strict';
+
     var datastoreObject = null;
 
     var activity = {};
@@ -51,7 +53,7 @@ define(["webL10n",
         // Colorize the activity icon.
         activity.getXOColor(function (error, colors) {
             icon.colorize(activityButton, colors);
-            invokerElem =
+            var invokerElem =
                 document.querySelector("#activity-palette .palette-invoker");
             icon.colorize(invokerElem, colors);
         });

--- a/activity/shortcut.js
+++ b/activity/shortcut.js
@@ -1,4 +1,7 @@
 define(function () {
+
+    'use strict';
+
     var shortcut = {};
 
     shortcut._allShortcuts = [];
@@ -39,7 +42,7 @@ define(function () {
         var key = String.fromCharCode(charCode).toLowerCase();
 
         // Search for a matching shortcut
-        for (i = 0; i < shortcut._allShortcuts.length; i += 1) {
+        for (var i = 0; i < shortcut._allShortcuts.length; i += 1) {
             var currentShortcut = shortcut._allShortcuts[i];
 
             var match = currentShortcut.key == key &&

--- a/bus.js
+++ b/bus.js
@@ -1,4 +1,7 @@
 define(["sugar-web/env"], function (env) {
+
+    'use strict';
+
     var lastId = 0;
     var callbacks = {};
     var notificationCallbacks = {};
@@ -70,7 +73,7 @@ define(["sugar-web/env"], function (env) {
 
     InputStream.prototype.read = function (count, callback) {
         if (this.readCallback) {
-            throw Error("Read already in progress");
+            throw new Error("Read already in progress");
         }
 
         this.readCallback = callback;

--- a/datastore.js
+++ b/datastore.js
@@ -1,4 +1,7 @@
 define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
+
+    'use strict';
+
     var datastore = {};
 
     function DatastoreObject(objectId) {
@@ -171,7 +174,7 @@ define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
     };
 
     datastore.load = function (objectId, callback) {
-        inputStream = bus.createInputStream();
+        var inputStream = bus.createInputStream();
 
         inputStream.open(function (error) {
             function onResponseReceived(responseError, result) {
@@ -201,7 +204,7 @@ define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
     };
 
     datastore.save = function (objectId, metadata, callback) {
-        outputStream = bus.createOutputStream();
+        var outputStream = bus.createOutputStream();
 
         outputStream.open(function (error) {
             function onResponseReceived(responseError, result) {

--- a/dictstore.js
+++ b/dictstore.js
@@ -1,5 +1,7 @@
 define(["sugar-web/activity/activity"], function (activity) {
 
+    'use strict';
+
     // This is a helper module that allows to persist key/value data
     // using the standard localStorage object.
     //

--- a/env.js
+++ b/env.js
@@ -1,5 +1,7 @@
 define(function () {
 
+    'use strict';
+
     var env = {};
 
     env.getEnvironment = function (callback) {

--- a/graphics/activitypalette.js
+++ b/graphics/activitypalette.js
@@ -1,6 +1,8 @@
 define(["sugar-web/graphics/palette",
         "text!sugar-web/graphics/activitypalette.html"], function (palette, template) {
 
+    'use strict';
+
     var activitypalette = {};
 
     activitypalette.ActivityPalette = function (activityButton,

--- a/graphics/grid.js
+++ b/graphics/grid.js
@@ -1,4 +1,7 @@
 define(function () {
+
+    'use strict';
+
     var grid = {};
 
     // Add a grid overlay with lines spaced by subcellSize, for visual

--- a/graphics/icon.js
+++ b/graphics/icon.js
@@ -1,4 +1,7 @@
 define(function () {
+
+    'use strict';
+
     var icon = {};
 
     function changeColors(iconData, fillColor, strokeColor) {

--- a/graphics/menupalette.js
+++ b/graphics/menupalette.js
@@ -1,6 +1,8 @@
 define(["sugar-web/graphics/palette",
         "text!sugar-web/graphics/menupalette.html", "mustache"], function (palette, template, mustache) {
 
+    'use strict';
+
     var menupalette = {};
 
     menupalette.MenuPalette = function (invoker, primaryText, menuData) {

--- a/graphics/palette.js
+++ b/graphics/palette.js
@@ -1,4 +1,7 @@
 define(function () {
+
+    'use strict';
+
     var palettesGroup = [];
 
     function getOffset(elem) {
@@ -73,7 +76,7 @@ define(function () {
             document.body.appendChild(paletteElem);
 
             if (that.invoker.classList.contains("toolbutton")) {
-                invokerElem = document.createElement('div');
+                var invokerElem = document.createElement('div');
                 invokerElem.className = "palette-invoker";
                 var style = that.invoker.currentStyle ||
                     window.getComputedStyle(that.invoker, '');
@@ -154,7 +157,7 @@ define(function () {
 
     palette.Palette.prototype.popUp = function () {
         for (var i = 0; i < palettesGroup.length; i++) {
-            otherPalette = palettesGroup[i];
+            var otherPalette = palettesGroup[i];
             if (otherPalette != this) {
                 otherPalette.popDown();
             }

--- a/graphics/radiobuttonsgroup.js
+++ b/graphics/radiobuttonsgroup.js
@@ -1,4 +1,7 @@
 define(function () {
+
+    'use strict';
+
     var radioButtonsGroup = {};
 
     // ## RadioButtonsGroup

--- a/graphics/xocolor.js
+++ b/graphics/xocolor.js
@@ -1,5 +1,7 @@
 define(function () {
 
+    'use strict';
+
     var xocolor = {};
 
     xocolor.colors = [

--- a/test/busSpec.js
+++ b/test/busSpec.js
@@ -1,5 +1,7 @@
 define(["sugar-web/bus"], function (bus) {
 
+    'use strict';
+
     describe("bus requests", function () {
         var client;
 

--- a/test/datastoreSpec.js
+++ b/test/datastoreSpec.js
@@ -1,5 +1,7 @@
 define(["sugar-web/bus", "sugar-web/datastore"], function (bus, datastore) {
 
+    'use strict';
+
     describe("datastore object", function () {
 
         beforeEach(function () {

--- a/test/envSpec.js
+++ b/test/envSpec.js
@@ -1,5 +1,7 @@
 define(["sugar-web/env"], function (env) {
 
+    'use strict';
+
     describe("environment", function () {
 
         it("should not return undefined", function () {

--- a/test/graphics/iconSpec.js
+++ b/test/graphics/iconSpec.js
@@ -1,4 +1,7 @@
 define(["sugar-web/graphics/icon"], function (icon) {
+
+    'use strict';
+
     describe("icon", function () {
         var wasLoaded;
         var iconUrlResult;

--- a/test/graphics/menupaletteSpec.js
+++ b/test/graphics/menupaletteSpec.js
@@ -1,4 +1,7 @@
 define(["sugar-web/graphics/menupalette", "sugar-web/graphics/palette"], function (menupalette, palette) {
+
+    'use strict';
+
     describe("menupalette", function () {
 
         var invoker;

--- a/test/graphics/paletteSpec.js
+++ b/test/graphics/paletteSpec.js
@@ -1,4 +1,7 @@
 define(["sugar-web/graphics/palette"], function (palette) {
+
+    'use strict';
+
     describe("palette", function () {
         it("should start down", function () {
             var invoker = document.createElement('button');

--- a/test/graphics/radiobuttonsgroupSpec.js
+++ b/test/graphics/radiobuttonsgroupSpec.js
@@ -1,6 +1,8 @@
 define(["sugar-web/graphics/radiobuttonsgroup"], function (
     radioButtonsGroup) {
 
+    'use strict';
+
     beforeEach(function () {
         elem1 = document.createElement('button');
         elem2 = document.createElement('button');


### PR DESCRIPTION
Avoid it on purpose in test/karma.conf.js and test/loader.js because
there are no functions there, only settings.

Also fix errors that were silenced before:
- if not using 'new' to instantiate a class, JSHint throws: "Missing
  'new' prefix when invoking a constructor"
- Console errors: "strict mode forbids implicit creation of global
  properties".  Some variables missed 'var'.
