### PR TITLE
test: Ensuring objectId to datastore object (datastore)

### DIFF
--- a/datastore.js
+++ b/datastore.js
@@ -11,9 +11,9 @@ define(["sugar-web/bus", "sugar-web/env"], function (bus, env) {
         this.ensureObjectId = function (callback) {
             var that = this;
 
-            env.getEnvironment(function (error, environment) {
-                if (environment.objectId !== null && that.objectId === undefined) {
-                    that.objectId = environment.objectId;
+            env.getObjectId(function (objectId) {
+                if (objectId !== null && that.objectId === undefined) {
+                    that.objectId = objectId;
                 }
                 callback();
             });

--- a/env.js
+++ b/env.js
@@ -25,5 +25,13 @@ define(function () {
         }
     };
 
+    env.getObjectId = function (callback) {
+        var objectId;
+        env.getEnvironment(function (error, environment) {
+            objectId = environment.objectId;
+            callback(objectId);
+        });
+    };
+
     return env;
 });

--- a/test/datastoreSpec.js
+++ b/test/datastoreSpec.js
@@ -1,6 +1,35 @@
-define(["sugar-web/bus", "sugar-web/datastore"], function (bus, datastore) {
+define(["sugar-web/bus", "sugar-web/env", "sugar-web/datastore"], function (bus, env, datastore) {
 
     'use strict';
+
+    describe("Ensuring objectId to datastore object", function () {
+
+        // require: datastore is not used in standalone mode
+        it("should have objectId", function () {
+
+            var objectId = "objectId";
+            spyOn(env, "getObjectId").andCallFake(function (callback){
+                setTimeout(function () {
+                    callback(objectId);
+                }, 5000);
+            });
+            var callback = jasmine.createSpy();
+
+            var datastoreObject = new datastore.DatastoreObject();
+
+            runs(function () {
+                datastoreObject.ensureObjectId(callback);
+            });
+
+            waitsFor(function () {
+                return datastoreObject.objectId !== undefined;
+            }, "should have objectId received from the environment");
+
+            runs(function () {
+                expect(callback).toHaveBeenCalled();
+            });
+        });
+    });
 
     describe("datastore object", function () {
 

--- a/test/envSpec.js
+++ b/test/envSpec.js
@@ -12,5 +12,25 @@ define(["sugar-web/env"], function (env) {
                 expect(environment.activityName).not.toBeUndefined();
             });
         });
+
+        it("should return objectId provided from the sugar's environment", function () {
+            var environment = {objectId: "objectId"};
+            spyOn(env, "getEnvironment").andCallFake(function (callback){
+                setTimeout(function () {
+                    callback(null, environment);
+                }, 5000);
+            });
+            var expected_objectId;
+
+            runs(function() {
+                env.getObjectId(function (objectId){
+                    expected_objectId = objectId;
+                });
+            });
+
+            waitsFor(function () {
+                return expected_objectId !== undefined;
+            }, "should return objectId");
+        });
     });
 });


### PR DESCRIPTION
The main goal of this pull request is that performed this test for testing the method that populates a datastore object with the objectId received from the sugar's environment.
If you look, you will notice that the new method I suggested getObjectId is not very important, but... I want to stress that gives better semantics and the important thing what motivated me to do that is to getEnvironment kick back, which is a method that is causing me to want to look for a way to solve it in another way, this motivated me to isolate here.
If you do not agree with this, and want to use the test anyway, I can remove getObjectId, but atomicity that it provides should always becoming useful.
