### PR TITLE
try2 - datastore integration tests: increase waitFor timeout

### DIFF
--- a/test/datastoreSpec.js
+++ b/test/datastoreSpec.js
@@ -2,6 +2,8 @@ define(["sugar-web/bus", "sugar-web/env", "sugar-web/datastore"], function (bus,
 
     'use strict';
 
+    var defaultTimeoutInterval = jasmine.getEnv().defaultTimeoutInterval;
+
     describe("Ensure the datastore object has an objectId", function () {
 
         // FIXME does not work in standalone mode
@@ -33,10 +35,14 @@ define(["sugar-web/bus", "sugar-web/env", "sugar-web/datastore"], function (bus,
     describe("datastore object", function () {
 
         beforeEach(function () {
+            //FIXME: due to db initialization,
+            //the very first save() call may take a while
+            jasmine.getEnv().defaultTimeoutInterval = 10000;
             bus.listen();
         });
 
         afterEach(function () {
+            jasmine.getEnv().defaultTimeoutInterval = defaultTimeoutInterval;
             bus.close();
         });
 
@@ -125,10 +131,14 @@ define(["sugar-web/bus", "sugar-web/env", "sugar-web/datastore"], function (bus,
     describe("datastore", function () {
 
         beforeEach(function () {
+            //FIXME: due to db initialization,
+            //the very first save() call may take a while
+            jasmine.getEnv().defaultTimeoutInterval = 10000;
             bus.listen();
         });
 
         afterEach(function () {
+            jasmine.getEnv().defaultTimeoutInterval = defaultTimeoutInterval;
             bus.close();
         });
 


### PR DESCRIPTION
http://lists.sugarlabs.org/archive/sugar-devel/2013-December/046395.html

Again: we are about to review datastore.js at any time... revisiting its tests, splitting the integration ones from unit ones and adding new ones (if necesary)
