### PR TITLE
Update to the latest karma config format

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -2,86 +2,81 @@
 // Generated on Mon May 13 2013 10:01:17 GMT-0300 (ART)
 
 
-// base path, that will be used to resolve files and exclude
-basePath = '..';
-
-
 // list of files / patterns to load in the browser
-files = [
-    JASMINE,
-    JASMINE_ADAPTER,
-    REQUIRE,
-    REQUIRE_ADAPTER,
-        'test/loader.js', {
-        pattern: 'test/**/*Spec.js',
-        included: false
-    }, {
-        pattern: 'lib/**/*.js',
-        included: false
-    }, {
-        pattern: '**/*.js',
-        exclude: 'test/**/*.js',
-        included: false
-    }, {
-        pattern: 'graphics/**/*.html',
-        included: false
-    }, {
-        pattern: 'graphics/**/*.css',
-        included: false
-    }, {
-        pattern: 'graphics/icons/**/*.svg',
-        included: false
-    }
-];
+module.exports = function (config) {
+    config.set({
+        frameworks: ['jasmine', 'requirejs'],
 
 
-// list of files to exclude
-exclude = [
-
-];
+        // base path, that will be used to resolve files and exclude
+        basePath: '..',
 
 
-// test results reporter to use
-// possible values: 'dots', 'progress', 'junit'
-reporters = ['progress'];
+        files: [
+            'test/loader.js',
+            {
+                pattern: 'test/**/*Spec.js',
+                included: false
+            }, {
+                pattern: 'lib/**/*.js',
+                included: false
+            }, {
+                pattern: '**/*.js',
+                exclude: 'test/**/*.js',
+                included: false
+            }, {
+                pattern: 'graphics/**/*.html',
+                included: false
+            }, {
+                pattern: 'graphics/**/*.css',
+                included: false
+            }, {
+                pattern: 'graphics/icons/**/*.svg',
+                included: false
+            }
+        ],
 
 
-// web server port
-port = 9876;
+        // list of files to exclude
+        exclude: [],
 
 
-// cli runner port
-runnerPort = 9100;
+        // test results reporter to use
+        // possible values: 'dots', 'progress', 'junit'
+        reporters: ['progress'],
 
 
-// enable / disable colors in the output (reporters and logs)
-colors = true;
+        // web server port
+        port: 9876,
 
 
-// level of logging
-// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-logLevel = LOG_INFO;
+        // cli runner port
+        runnerPort: 9100,
 
 
-// enable / disable watching file and executing tests whenever any file changes
-autoWatch = true;
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
 
 
-// Start these browsers, currently available:
-// - Chrome
-// - ChromeCanary
-// - Firefox
-// - Opera
-// - Safari (only Mac)
-// - PhantomJS
-// - IE (only Windows)
-browsers = ["sugar-web-test"];
+        // level of logging
+        // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO ||
+        // LOG_DEBUG
+        logLevel: config.LOG_INFO,
 
 
-// If browser does not capture in given timeout [ms], kill it
-captureTimeout = 60000;
+        // enable / disable watching file and executing tests whenever any file
+        // changes
+        autoWatch: true,
 
 
-// Continuous Integration mode
-// if true, it capture browsers, run tests and exit
-singleRun = false;
+        // If browser does not capture in given timeout [ms], kill it
+        captureTimeout: 60000,
+
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: false,
+
+        preprocessors: {}
+    });
+};


### PR DESCRIPTION
We don't specific browsers in the config anymore, we will
pass it transparenty on the command line from sugar-build.
This is because we need the full path now and we cannot
hard code that.
