### PR TITLE
Add a method to show a alert with the Sugar style

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -129,5 +129,36 @@ define(["webL10n",
         bus.sendMessage("activity.show_object_chooser", [], onResponseReceived);
     };
 
+    activity.showAlert = function (title, message, btnLabel, btnCallback) {
+        if (btnLabel == null) {
+            btnLabel = 'Ok';
+        }
+
+        var fragment = document.createDocumentFragment();
+        var div = document.createElement('div');
+        div.className = 'alert';
+        div.id = 'activity-alert';
+        div.innerHTML = '<p><b>' + title + '</b><br/>' + message + '</p>' +
+            '<p class="button-box">' +
+            '<button id="actvity-alert-btn" class="icon">' +
+            '<span class="ok"></span>' +
+            btnLabel + '</button></p>';
+        fragment.appendChild(div);
+
+        document.body.appendChild(fragment.cloneNode(true));
+
+        var btn = document.getElementById("actvity-alert-btn");
+        btn.addEventListener('click', function (e) {
+            var alertNode = document.getElementById("activity-alert");
+            if (alertNode.parentNode) {
+                alertNode.parentNode.removeChild(alertNode);
+            }
+            if (btnCallback != null) {
+                btnCallback();
+            }
+        });
+
+    };
+
     return activity;
 });

--- a/graphics/css/sugar-200dpi.css
+++ b/graphics/css/sugar-200dpi.css
@@ -80,6 +80,34 @@ a {
 .toolbar #stop-button {
   background-image: url('../icons/actions/activity-stop.svg');
 }
+/* Alert */
+.alert {
+  position: absolute;
+  top: 75px;
+  z-index: 10;
+  height: 75px;
+  width: 100%;
+  color: white;
+  background-color: black;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
+.alert p {
+  padding-left: 15px;
+  vertical-align: middle;
+  width: 80%;
+}
+.alert .button-box {
+  position: fixed;
+  top: 75px;
+  right: 0px;
+  height: 75px;
+  width: 20%;
+  margin: 15px;
+}
+.alert button {
+  float: right;
+}
 /* Canvas */
 #canvas {
   position: absolute;

--- a/graphics/css/sugar-96dpi.css
+++ b/graphics/css/sugar-96dpi.css
@@ -80,6 +80,34 @@ a {
 .toolbar #stop-button {
   background-image: url('../icons/actions/activity-stop.svg');
 }
+/* Alert */
+.alert {
+  position: absolute;
+  top: 55px;
+  z-index: 10;
+  height: 55px;
+  width: 100%;
+  color: white;
+  background-color: black;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
+.alert p {
+  padding-left: 11px;
+  vertical-align: middle;
+  width: 80%;
+}
+.alert .button-box {
+  position: fixed;
+  top: 55px;
+  right: 0px;
+  height: 55px;
+  width: 20%;
+  margin: 11px;
+}
+.alert button {
+  float: right;
+}
 /* Canvas */
 #canvas {
   position: absolute;

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -123,6 +123,39 @@ a {
   background-image: url('../icons/actions/activity-stop.svg');
 }
 
+
+/* Alert */
+.alert {
+  position: absolute;
+  top: @toolbar-height;
+  z-index:10;
+  height: @toolbar-height;
+  width: 100%;
+  color: white;
+  background-color: black;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
+
+.alert p {
+  padding-left: @subcell-size;
+  vertical-align: middle;
+  width: 80%;
+}
+
+.alert .button-box{
+  position: fixed;
+  top: @toolbar-height;
+  right: 0px;
+  height: @toolbar-height;
+  width: 20%;
+  margin: @subcell-size;
+}
+
+.alert button {
+  float: right;
+}
+
 /* Canvas */
 
 #canvas {


### PR DESCRIPTION
The usage is:
  activity.showAlert(title, message, btnLabel, btnCallback);

The last two parametter can be null.
By default btnLabel will be 'Ok' and pressing the button will close the alert.
If btnCallback is not null, the alert will be closed, and the function will
be executed.
Example:
  activity.showAlert('ERROR',
                     'Words should be at least 3 character long', null,
                     function() {child.focus();});
