### PR TITLE
Loading the activity palette template breaks activity working on browsers

### DIFF
--- a/graphics/activitypalette.html
+++ b/graphics/activitypalette.html
@@ -1,9 +1,0 @@
-<div class="row">
-  <input type="text" id="title" class="expand">
-</div>
-<div class="row small">
-  <label>Description:</label>
-</div>
-<div class="row expand">
-  <textarea rows="8" id="description" class="expand"></textarea>
-</div>

--- a/graphics/activitypalette.js
+++ b/graphics/activitypalette.js
@@ -1,5 +1,4 @@
-define(["sugar-web/graphics/palette",
-        "text!sugar-web/graphics/activitypalette.html"], function (palette, template) {
+define(["sugar-web/graphics/palette"], function (palette, template) {
 
     'use strict';
 
@@ -17,7 +16,17 @@ define(["sugar-web/graphics/palette",
         this.getPalette().id = "activity-palette";
 
         var containerElem = document.createElement('div');
-        containerElem.innerHTML = template;
+
+        containerElem.innerHTML = '<div class="row">' +
+            '<input type="text" id="title" class="expand">' +
+            '</div>' +
+            '<div class="row small">' +
+            '<label>Description:</label>' +
+            '</div>' +
+            '<div class="row expand">' +
+            '<textarea rows="8" id="description" class="expand"></textarea>' +
+            '</div>';
+
         this.setContent([containerElem]);
 
         this.titleElem = containerElem.querySelector('#title');


### PR DESCRIPTION
The activitypalette.js try to open a html file to use it as a template.
When the activity is started n a browser, opening the index.html file
using the file:/// protocol, and try  to open the file give a error 
"Cross origin requests are only supported for HTTP."
The template is really simple, we can include it in the js file instead.
