### PR TITLE
Fix textarea expanding, fixes #4832

### DIFF
--- a/graphics/css/sugar-200dpi.css
+++ b/graphics/css/sugar-200dpi.css
@@ -478,5 +478,10 @@ ul.flat-list.striped li:nth-child(odd) {
 }
 /* ActivityPalette */
 #activity-palette .wrapper {
-  width: 371px;
+  min-width: 371px;
+  max-width: none;
+}
+#activity-palette .wrapper textarea {
+  min-width: 371px;
+  min-height: 8em;
 }

--- a/graphics/css/sugar-96dpi.css
+++ b/graphics/css/sugar-96dpi.css
@@ -478,5 +478,10 @@ ul.flat-list.striped li:nth-child(odd) {
 }
 /* ActivityPalette */
 #activity-palette .wrapper {
-  width: 271px;
+  min-width: 271px;
+  max-width: none;
+}
+#activity-palette .wrapper textarea {
+  min-width: 271px;
+  min-height: 8em;
 }

--- a/graphics/css/sugar.less
+++ b/graphics/css/sugar.less
@@ -616,5 +616,11 @@ ul.flat-list.striped li:nth-child(odd) {
 /* ActivityPalette */
 
 #activity-palette .wrapper {
-  width: 5 * @cell-size - 2 * @line-width;
+  min-width: 5 * @cell-size - 2 * @line-width;
+  max-width: none;
+}
+
+#activity-palette .wrapper textarea {
+  min-width: 5 * @cell-size - 2 * @line-width;
+  min-height: 8em;
 }


### PR DESCRIPTION
This commit makes the palette expand on the x-axis when the textarea
in the activity palette is expanded.  This means it does not overflow.

This commit also puts limits on the size of the text area, so the user
can not drag it to be small and weird looking.

Bug link:  http://bugs.sugarlabs.org/ticket/4832