### PR TITLE
Use 0.0.0.0 instead of localhost

### DIFF
--- a/bus.js
+++ b/bus.js
@@ -16,7 +16,7 @@ define(["sugar-web/env"], function (env) {
 
         env.getEnvironment(function (error, environment) {
             var port = environment.apiSocketPort;
-            var socket = new WebSocket("ws://localhost:" + port);
+            var socket = new WebSocket("ws://0.0.0.0:" + port);
 
             socket.binaryType = "arraybuffer";
 


### PR DESCRIPTION
As previously discussed in [1] and [2], all web activities running in
sugar shell should use "0.0.0.0" instead of "localhost", considering
the server is always going to be used via the local network interface.

This fixes the problem in Ubuntu 14.04 LTS where libsoup is not able
to resolve localhost when no active network is present, breaking web
activities integration with sugar shell.

[1] https://dev.laptop.org/ticket/12479
[2] https://dev.laptop.org/ticket/12503

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>