### PR TITLE
Use more compatible way to create CustomEvent

### DIFF
--- a/activity/activity.js
+++ b/activity/activity.js
@@ -19,10 +19,9 @@ define(["webL10n",
         l10n.start();
 
         function sendPauseEvent() {
-            var pauseEvent = new CustomEvent(
-                "activityPause", {
-                    cancelable: true
-                });
+            var pauseEvent = document.createEvent("CustomEvent");
+            pauseEvent.initCustomEvent('activityPause', false, false, {
+                                       'cancelable': true});
             window.dispatchEvent(pauseEvent);
         }
         bus.onNotification("activity.pause", sendPauseEvent);
@@ -32,10 +31,10 @@ define(["webL10n",
         // call activity.close() after storing.
 
         function sendStopEvent() {
-            var stopEvent = new CustomEvent(
-                "activityStop", {
-                    cancelable: true
-                });
+            var stopEvent = document.createEvent("CustomEvent");
+            stopEvent.initCustomEvent('activityStop', false, false, {
+                                      'cancelable': true});
+
             var result = window.dispatchEvent(stopEvent);
             if (result) {
                 activity.close();

--- a/graphics/menupalette.js
+++ b/graphics/menupalette.js
@@ -8,14 +8,10 @@ define(["sugar-web/graphics/palette",
     menupalette.MenuPalette = function (invoker, primaryText, menuData) {
         palette.Palette.call(this, invoker, primaryText);
 
-        this.selectItemEvent = new CustomEvent(
-            "selectItem", {
-                detail: {
-                    item: undefined
-                },
-                bubbles: true,
-                cancelable: true
-            });
+        var selectItemEvent = document.createEvent("CustomEvent");
+        selectItemEvent.initCustomEvent('selectItem', true, true, {
+            'item': undefined
+        });
 
         var menuElem = document.createElement('ul');
         menuElem.className = "menu";


### PR DESCRIPTION
As reported by Lionel:
"Like lot of HTML5 features, CustomEvent is only a draft.
BTW the version without constructor [1] is currently more deployed in browsers
than the one with a constructor [2].
The sugar-web template use the later in two files activity.js and menupalette.js.
It's possible to convert the call to the version with constructor to the version
without constructor without changing the way of working of the code."

This change allow the code run in Android devices.

[1] https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#interface-CustomEvent
[2] https://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#interface-customevent

Email: http://lists.sugarlabs.org/archive/sugar-devel/2014-June/048420.html