### PR TITLE
Make palettes behave like sugar-toolkit.

### DIFF
--- a/graphics/palette.js
+++ b/graphics/palette.js
@@ -162,6 +162,16 @@ define(function () {
                 otherPalette.popDown();
             }
         }
+        var that = this;
+        function closePalette() {
+            that.getPalette().style.visibility = "hidden";
+            document.body.removeEventListener("click", closePalette);
+            window.removeEventListener("blur", closePalette);
+            }
+        setTimeout( function() {
+            document.body.addEventListener("click", closePalette);
+            window.addEventListener("blur", closePalette);
+        });
         this.getPalette().style.visibility = "visible";
     };
 


### PR DESCRIPTION
They will close when clicking anywere else.

@llaske you may be interested in this one. Makes palettes less frustrating.