### PR TITLE
Fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Sugar Web
 These are the tools that a developer can use to make a web
 activity.
 
-For details see: http://developer.sugarlabs.org/
+For details see: https://github.com/sugarlabs/sugar-docs/blob/master/README.md


### PR DESCRIPTION
The link to the developer docs on sugarlabs/sugar-web was broken.
Changing it from https://developer.sugarlabs.org to sugarlabs/sugar-docs.

Fixes https://github.com/sugarlabs/sugar-web/issues/131